### PR TITLE
Configurando um método privado para ter acesso a string de banco de dados

### DIFF
--- a/InfraEstrutura/Configuration/ContextBase.cs
+++ b/InfraEstrutura/Configuration/ContextBase.cs
@@ -25,7 +25,7 @@ namespace Infrastructure.Configuration
             {
                 //provisóriamente deixaremos a string vazia caso não haja 
                 //uma string de configuração
-                optionsBuilder.UseSqlServer(string.Empty);
+                optionsBuilder.UseSqlServer(GetStringConnectionConfig());
                 base.OnConfiguring(optionsBuilder);
             }
         }


### PR DESCRIPTION
usei um método private para tornar seguro o acesso ao banco de dados usando uma string de conexão, tornando o acesso a esssa string possível, apenas na classe de contexto